### PR TITLE
Fix project links ending in .html

### DIFF
--- a/src/ProjectsService.js
+++ b/src/ProjectsService.js
@@ -13,7 +13,7 @@ const prepareProjects = (projects) => {
       name: el.name,
       description: el.description,
       imageUrl: el.imageUrl,
-      link: el.link ? BASE_URL + el.link : el.link,
+      link: el.link ? BASE_URL + el.link.replace(/\.html$/, '') : el.link,
       tags: el.tags,
       topic: el.topic,
       quarter: el.quarter,


### PR DESCRIPTION
Hugo omits the html extension, so in order for the links to be correct, they must have their .html ending stripped.